### PR TITLE
Fix Incident body

### DIFF
--- a/lib/statuspageio/client/incident.rb
+++ b/lib/statuspageio/client/incident.rb
@@ -67,13 +67,13 @@ module Statuspageio
 
         raise ArgumentError, 'name is required' if create_opts[:name].nil? || create_opts[:name].empty?
 
-        post("/pages/#{page_id}/incidents", create_opts)
+        post("/pages/#{page_id}/incidents", incident: create_opts)
       end
 
       def update_incident(incident_id, opts = {})
         update_opts = allowlist_opts(symbolize_keys(opts))
 
-        put("/pages/#{page_id}/incidents/#{incident_id}", update_opts)
+        put("/pages/#{page_id}/incidents/#{incident_id}", incident: update_opts)
       end
 
       private

--- a/lib/statuspageio/client/subscriber.rb
+++ b/lib/statuspageio/client/subscriber.rb
@@ -36,7 +36,7 @@ module Statuspageio
         create_options = symbolize_keys(options).slice(*SUBSCRIBER_OPTIONS)
 
         if valid_for_subscribing?(create_options)
-          post("/pages/#{page_id}/subscribers", { subscriber: create_options })
+          post("/pages/#{page_id}/subscribers", subscriber: create_options)
         else
           raise ArgumentError, 'An email address or phone number with the two digit country code '\
                                'is required'

--- a/spec/incident_spec.rb
+++ b/spec/incident_spec.rb
@@ -201,7 +201,7 @@ describe Statuspageio::Client::Incident do
     context 'with valid options' do
       before do
         stub_request(:post, request_url).
-          with(body: options.to_json).
+          with(body: { incident: options }.to_json).
           to_return(body: body, status: 201)
       end
 
@@ -213,7 +213,7 @@ describe Statuspageio::Client::Incident do
     context 'with invalid options' do
       before do
         stub_request(:post, request_url).
-          with(body: options.to_json).
+          with(body: { incident: options }.to_json).
           to_return(body: body, status: 201)
       end
 
@@ -229,7 +229,7 @@ describe Statuspageio::Client::Incident do
 
       before do
         stub_request(:post, request_url).
-          with(body: { name: 'Incident 2' }.to_json).
+          with(body: { incident: { name: 'Incident 2' } }.to_json).
           to_return(body: body, status: 201)
       end
 
@@ -263,7 +263,7 @@ describe Statuspageio::Client::Incident do
     context 'with valid options' do
       before do
         stub_request(:put, request_url).
-          with(body: options.to_json).
+          with(body: { incident: options }.to_json).
           to_return(body: body, status: 200)
       end
 


### PR DESCRIPTION
In master branch, when trying to use `#create_incident` it returns
the following error: Statuspageio::ResponseError: 400 Bad Request error: incident is missing, incident[name] is missing

This adds the key and updates tests.

Fixes #7